### PR TITLE
Add encoding parameter to transaction.do method

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ deployment.result
 # Retrieve the metadata components specified in package.xml and unzip to the "retrieved" directory
 client.retrieve(File.expand_path('path/to/package.xml')).to('retrieved')
 
+# Specify an alternate encoding
+client.retrieve(File.expand_path('path/to/package.xml')).to('retrieved', 'ascii-8bit')
+
 # Create a Visualforce page
 client.create_apex_page(:full_name => 'TestPage', :label => 'TestPage')
 

--- a/lib/metaforce/metadata/transaction.rb
+++ b/lib/metaforce/metadata/transaction.rb
@@ -48,7 +48,13 @@ module Metaforce
     # Unzips the returned zip file to +destination+.
     def to(destination, encoding=nil)
       zip = zip_file
-      file = Tempfile.new('retrieve', :encoding => encoding if encoding.present?)
+      
+      if encoding.present?
+        file = Tempfile.new('retrieve', :encoding => encoding)
+      else
+        file = Tempfile.new('retrieve')
+      end
+
       file.write(zip)
       path = file.path
       file.close

--- a/lib/metaforce/metadata/transaction.rb
+++ b/lib/metaforce/metadata/transaction.rb
@@ -46,9 +46,9 @@ module Metaforce
     end
 
     # Unzips the returned zip file to +destination+.
-    def to(destination)
+    def to(destination, encoding=nil)
       zip = zip_file
-      file = Tempfile.new('retrieve')
+      file = Tempfile.new('retrieve', :encoding => encoding if encoding.present?)
       file.write(zip)
       path = file.path
       file.close


### PR DESCRIPTION
Ran into a problem when using the gem in Rails where it didn't like the encoding of the TempFile in the transaction.to method. Proposing pull request to include the encoding as an optional parameter.

Example:
client.retrieve(File.expand_path('path/to/package.xml')).to('retrieved', 'ascii-8bit')
