### PR TITLE
Add highline as a dependency to avoid the error during require.

### DIFF
--- a/metaforce.gemspec
+++ b/metaforce.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "savon", "~> 0.9.7"
   s.add_dependency "rubyzip", "~> 0.9.5"
   s.add_dependency "term-ansicolor"
+  s.add_dependency "highline", "~> 1.6.11"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"


### PR DESCRIPTION
I tried to test this locally & it does install highline when I set metaforce to point to the locally built gem using `gem build` but for some reason, requiring in irb gives `LoadError: cannot load such file -- ../metaforce`. It might be because I am missing some step. Let me know if there is a way you know where I can properly test this.
