### PR TITLE
Metaforce commandline with thor.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ examples/tmp
 deploy.zip
 retrieve.zip
 test.rb
+.metaforce.yml

--- a/README.md
+++ b/README.md
@@ -125,6 +125,37 @@ client.send_email(
 )
 ```
 
+## Commandline
+
+Metaforce also comes with a handy command line utility that can deploy and retrieve
+code from Salesforce. It also allows you to watch a directory and deploy when
+anything changes.
+
+When you deploy, it will also run all tests and provide you with a report,
+similar to rspec.
+
+```bash
+$ metaforce deploy ./src
+Deploying: ./src
+```
+
+```bash
+$ metaforce watch ./src
+Watching: ./src
+```
+
+```bash
+$ metaforce retrieve ./src/package.xml ./src
+Retrieving: ./src
+```
+
+### .metaforce.yml
+
+The metaforce command will pull it's configuration from a `.metaforce.yml`
+file, if present. You can provide options for multiple environments, then use
+the `-e` swtich on the command line to use an environment. See the
+[examples](examples) directory for an example.
+
 ## Contributing
 
 1. Fork it

--- a/bin/metaforce
+++ b/bin/metaforce
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+require 'rubygems'
+require 'bundler/setup'
+require 'metaforce'
+
+begin
+  require 'metaforce/cli'
+  Metaforce::CLI.start
+rescue Interrupt => e
+  puts "\nQuitting..."
+  exit 1
+rescue SystemExit => e
+  exit e.status
+end

--- a/examples/.metaforce.yml
+++ b/examples/.metaforce.yml
@@ -1,0 +1,10 @@
+# This is purely an example.
+---
+production:
+  username: foo@bar.com
+  password: foobarpassword
+  security_token: adwk2udj29
+developer:
+  username: foodev@bar.com
+  password: foobardevpassword
+  security_token: jiejw2udj29

--- a/lib/metaforce/cli.rb
+++ b/lib/metaforce/cli.rb
@@ -1,0 +1,103 @@
+require 'listen'
+require 'thor'
+require 'metaforce/reporters'
+require 'metaforce/reporters'
+
+Metaforce.configuration.log = false
+Metaforce::Job.disable_threading!
+
+module Metaforce
+  class CLI < Thor
+    CONFIG_FILE = '.metaforce.yml'
+
+    include Thor::Actions
+
+    class << self
+      def credential_options
+        method_option :username, :aliases => '-u', :desc => 'Username.'
+        method_option :password, :aliases => '-p', :desc => 'Password.'
+        method_option :security_token, :aliases => '-t', :desc => 'Security Token.'
+        method_option :environment, :aliases => '-e', :default => 'production', :desc => 'Environment to use from config file (if present).'
+        method_option :host, :aliases => '-h', :desc => 'Salesforce host to connect to.'
+      end
+
+      def deploy_options
+        method_option :deploy_options, :aliases => '-o', :type => :hash, :default => { :run_all_tests => true }, :desc => 'Deploy Options'
+      end
+
+      def retrieve_options
+        method_option :retrieve_options, :aliases => '-o', :type => :hash, :default => {}, :desc => 'Retrieve Options'
+      end
+    end
+
+    desc 'deploy <path>', 'Deploy <path> to the target organization.'
+
+    credential_options
+    deploy_options
+
+    def deploy(path)
+      say "Deploying: #{path}", :cyan
+      client(options).deploy(path, options[:deploy_options])
+        .on_complete { |job| Metaforce::Reporters::DeployReporter.new(job.result).report }
+        .on_error(&error)
+        .on_poll(&polling)
+        .perform
+    end
+
+    desc 'retrieve <manifest> <path>', 'Retrieve the components specified in <manifest> (package.xml) to <path>.'
+
+    credential_options
+    retrieve_options
+
+    def retrieve(manifest, path)
+      say "Retrieving: #{manifest}", :cyan
+      client(options).retrieve_unpackaged(manifest, options[:retrieve_options])
+        .extract_to(path)
+        .on_complete { |job| Metaforce::Reporters::RetrieveReporter.new(job.result).report }
+        .on_complete { |job| say "Extracted: #{path}", :green }
+        .on_error(&error)
+        .on_poll(&polling)
+        .perform
+    end
+
+    desc 'watch <path>', 'Deploy <path> to the target organization whenever files are changed.'
+
+    credential_options
+    deploy_options
+
+    def watch(path)
+      say "Watching: #{path}"
+      Listen.to(path) { deploy path }
+    end
+
+  private
+
+    def error
+      proc { |job| say "Error: #{job.result.inspect}" }
+    end
+
+    def polling
+      proc { |job| say 'Polling ...', :cyan }
+    end
+
+    def client(options)
+      credentials = Thor::CoreExt::HashWithIndifferentAccess.new(config ? config[options[:environment]] : {})
+      credentials.merge!(options.slice(:username, :password, :security_token, :host))
+      credentials.tap do |credentials|
+        credentials[:username] ||= ask('username:')
+        credentials[:password] ||= ask('password:')
+        credentials[:security_token] ||= ask('security token:')
+      end
+      Metaforce.new credentials
+    end
+
+    def config
+      YAML.load(File.open(config_file)) if File.exists?(config_file)
+    end
+
+    def config_file
+      File.expand_path(CONFIG_FILE)
+    end
+
+  end
+end

--- a/lib/metaforce/metadata/client/file.rb
+++ b/lib/metaforce/metadata/client/file.rb
@@ -97,7 +97,7 @@ module Metaforce
           package = if manifest.is_a?(Metaforce::Manifest)
             manifest
           elsif manifest.is_a?(String)
-            Metaforce::Manifest.new(File.open(manifest).read)
+            Metaforce::Manifest.new(::File.open(manifest).read)
           end
           options = {
             :api_version    => Metaforce.configuration.api_version,

--- a/lib/metaforce/reporters.rb
+++ b/lib/metaforce/reporters.rb
@@ -1,0 +1,2 @@
+require 'metaforce/reporters/deploy_reporter'
+require 'metaforce/reporters/retrieve_reporter'

--- a/lib/metaforce/reporters/base_reporter.rb
+++ b/lib/metaforce/reporters/base_reporter.rb
@@ -1,0 +1,52 @@
+require 'thor/shell/color'
+
+module Metaforce
+  module Reporters
+    class BaseReporter < Thor::Shell::Color
+      def initialize(results)
+        super()
+        @results = results
+      end
+
+      def report
+      end
+
+      def report_problems
+        return unless problems.any?
+        say
+        say "Problems:", :red
+        say
+        problems.each { |message| problem(message) }
+      end
+
+      def problem(message)
+        say "#{short_padding}#{message.file_name}:#{message.line_number}", :red
+        say "#{long_padding}#{message.problem}"
+        say
+      end
+
+      def short_padding
+        '  '
+      end
+
+      def long_padding
+        '     '
+      end
+
+    private
+
+      def messages
+        @messages ||= begin
+          messages = @results.messages || []
+          messages = [messages] unless messages.is_a?(Array)
+          messages
+        end
+      end
+
+      def problems
+        messages.select { |message| message.problem }
+      end
+
+    end
+  end
+end

--- a/lib/metaforce/reporters/deploy_reporter.rb
+++ b/lib/metaforce/reporters/deploy_reporter.rb
@@ -1,0 +1,65 @@
+require 'metaforce/reporters/base_reporter'
+
+module Metaforce
+  module Reporters
+    class DeployReporter < BaseReporter
+
+      def report
+        report_problems
+        report_failed_tests
+        report_test_results if report_test_results?
+      end
+
+      def report_failed_tests
+        return unless failures.any?
+        say
+        say "Failures:", :red
+        say
+        failures.each { |failure| failed(failure) }
+      end
+
+      def report_test_results
+        say
+        say "Finished in #{total_time} seconds"
+        say "#{num_tests} tests, #{num_failures} failures", num_failures > 0 ? :red : :green
+      end
+
+      def failed(failure)
+        say "#{short_padding}#{failure.stack_trace}:", :red
+        say "#{long_padding}#{failure.message}"
+        say
+      end
+
+    private
+
+      def report_test_results?
+        @results.success && problems.empty?
+      end
+
+      def test_results
+        @results.run_test_result
+      end
+
+      def failures
+        @failures ||= begin
+          failures = test_results.failures || []
+          failures = [failures] unless failures.is_a?(Array)
+          failures
+        end
+      end
+
+      def total_time
+        test_results.total_time
+      end
+
+      def num_tests
+        test_results.num_tests_run.to_i
+      end
+
+      def num_failures
+        test_results.num_failures.to_i
+      end
+
+    end
+  end
+end

--- a/lib/metaforce/reporters/retrieve_reporter.rb
+++ b/lib/metaforce/reporters/retrieve_reporter.rb
@@ -1,0 +1,11 @@
+require 'metaforce/reporters/base_reporter'
+
+module Metaforce
+  module Reporters
+    class RetrieveReporter < BaseReporter
+      def report
+        report_problems
+      end
+    end
+  end
+end

--- a/metaforce.gemspec
+++ b/metaforce.gemspec
@@ -24,7 +24,10 @@ EOL
   s.add_dependency 'savon', '~> 1.2.0'
   s.add_dependency 'rubyzip', '~> 0.9.9'
   s.add_dependency 'activesupport'
-  s.add_dependency 'hashie'
+  s.add_dependency 'hashie', '~> 1.2.0'
+  s.add_dependency 'thor', '~> 0.16.0'
+  s.add_dependency 'listen', '~> 0.6.0'
+  s.add_dependency 'rb-fsevent', '~> 0.9.1'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'

--- a/spec/lib/cli_spec.rb
+++ b/spec/lib/cli_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+require 'metaforce/cli'
+
+describe Metaforce::CLI do
+  before do
+    Metaforce::Client.any_instance.stub(:deploy).and_return(double('deploy job').as_null_object)
+    Metaforce::Client.any_instance.stub(:retrieve).and_return(double('retrieve job').as_null_object)
+    subject.stub(:config).and_return(nil)
+  end
+
+  describe 'credentials' do
+    let(:output) { capture(:stdout) { subject.deploy('./path') } }
+
+    context 'when supplied credentials from the command line' do
+      let(:options) { indifferent_hash(:username => 'foo', :password => 'bar', :security_token => 'token') }
+
+      it 'uses supplied credentials from command line' do
+        subject.options = options
+        Metaforce.should_receive(:new).with(indifferent_hash(options)).and_call_original
+        output.should include('Deploying: ./path')
+      end
+    end
+
+    context 'when supplied credentials from config file' do
+      let(:options) { indifferent_hash(:environment => 'production') }
+      let(:config) { { 'username' => 'foo', 'password' => 'bar', 'security_token' => 'token' } }
+
+      it 'uses credentials from the config file' do
+        subject.options = options
+        subject.stub(:config).and_return('production' => config)
+        Metaforce.should_receive(:new).with(indifferent_hash(config)).and_call_original
+        output.should include('Deploying: ./path')
+      end
+    end
+  end
+
+  def indifferent_hash(hash)
+    Thor::CoreExt::HashWithIndifferentAccess.new(hash)
+  end
+end

--- a/spec/lib/reporters/base_reporter_spec.rb
+++ b/spec/lib/reporters/base_reporter_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+require 'metaforce/reporters/base_reporter'
+
+describe Metaforce::Reporters::BaseReporter do
+  let(:results) { Hashie::Mash.new(success: true) }
+  let(:reporter) { described_class.new results }
+
+  describe '.problem' do
+    context 'when a line_number is present' do
+      let(:problem) { Hashie::Mash.new(file_name: 'path/file', line_number: '10', problem: 'Foobar') }
+
+      it 'prints the problem' do
+        reporter.should_receive(:say).with('  path/file:10', :red)
+        reporter.should_receive(:say).with('     Foobar')
+        reporter.should_receive(:say).with
+        reporter.problem(problem)
+      end
+    end
+
+    context 'when there is no line number present' do
+      let(:problem) { Hashie::Mash.new(file_name: 'path/file', problem: 'Foobar') }
+
+      it 'prints the problem' do
+        reporter.should_receive(:say).with('  path/file:', :red)
+        reporter.should_receive(:say).with('     Foobar')
+        reporter.should_receive(:say).with
+        reporter.problem(problem)
+      end
+    end
+  end
+
+  describe '.report_problems' do
+    context 'when there are no problems' do
+      it 'does not report any problems' do
+        reporter.should_receive(:say).never
+        reporter.should_receive(:problem).never
+        reporter.report_problems
+      end
+    end
+
+    context 'when there are problems' do
+      let(:results) { Hashie::Mash.new(success: true, messages: { problem: 'Problem', file_name: 'path/file', line_number: '10' }) }
+
+      it 'prints each problem' do
+        reporter.should_receive(:say)
+        reporter.should_receive(:say).with('Problems:', :red)
+        reporter.should_receive(:say)
+        reporter.should_receive(:problem)
+        reporter.report_problems
+      end
+    end
+  end
+end

--- a/spec/lib/reporters/deploy_reporter_spec.rb
+++ b/spec/lib/reporters/deploy_reporter_spec.rb
@@ -1,0 +1,106 @@
+require 'spec_helper'
+require 'metaforce/reporters/deploy_reporter'
+
+describe Metaforce::Reporters::DeployReporter do
+  let(:results) { Hashie::Mash.new(success: true) }
+  let(:reporter) { described_class.new results }
+
+  describe '.failed' do
+    let(:failure) { Hashie::Mash.new(stack_trace: 'stack trace', message: 'message') }
+
+    it 'prints the failure' do
+      reporter.should_receive(:say).with('  stack trace:', :red)
+      reporter.should_receive(:say).with('     message')
+      reporter.should_receive(:say).with
+      reporter.failed(failure)
+    end
+  end
+
+  describe '.report' do
+    context 'when the deploy was successfull' do
+      it 'should report everything' do
+        reporter.should_receive(:report_problems)
+        reporter.should_receive(:report_failed_tests)
+        reporter.should_receive(:report_test_results)
+        reporter.report
+      end
+    end
+
+    context 'when the deploy was not successful' do
+      let(:results) { Hashie::Mash.new(success: false) }
+
+      it 'should report everything except test results' do
+        reporter.should_receive(:report_problems)
+        reporter.should_receive(:report_failed_tests)
+        reporter.should_receive(:report_test_results).never
+        reporter.report
+      end
+    end
+  end
+
+  describe '.report_failed_tests' do
+    let(:results) { Hashie::Mash.new(success: true, run_test_result: { failures: failures }) }
+
+    context 'when there are no failed tests' do
+      let(:failures) { nil }
+
+      it 'does not report any failed tests' do
+        reporter.should_receive(:say).never
+        reporter.should_receive(:failed).never
+        reporter.report_failed_tests
+      end
+    end
+
+    context 'when there are failed tests' do
+      context 'passed as an object' do
+        let(:failures) { { stack_trace: 'stack trace', message: 'message' } }
+
+        it 'prints each failed tests' do
+          reporter.should_receive(:say)
+          reporter.should_receive(:say).with('Failures:', :red)
+          reporter.should_receive(:say)
+          reporter.should_receive(:failed)
+          reporter.report_failed_tests
+        end
+      end
+      
+      context 'passed as an array' do
+        let(:failures) { [{ stack_trace: 'stack trace', message: 'message' }, { stack_trace: 'stack trace 2', message: 'message 2' }] }
+
+        it 'prints each failed tests' do
+          reporter.should_receive(:say)
+          reporter.should_receive(:say).with('Failures:', :red)
+          reporter.should_receive(:say)
+          reporter.should_receive(:failed).twice
+          reporter.report_failed_tests
+        end
+      end
+    end
+  end
+
+  describe '.report_test_results' do
+    let(:results) { Hashie::Mash.new(success: true, run_test_result: { total_time: '20', num_tests_run: '10', num_failures: num_failures }) }
+
+    context 'when there are failures' do
+      let(:num_failures) { '5' }
+
+      it 'prints the test results in red' do
+        reporter.should_receive(:say)
+        reporter.should_receive(:say).with("Finished in 20 seconds")
+        reporter.should_receive(:say).with("10 tests, 5 failures", :red)
+        reporter.report_test_results
+      end
+    end
+
+    context 'when there are no failures' do
+      let(:num_failures) { '0' }
+
+      it 'prints the test results in red' do
+        reporter.should_receive(:say)
+        reporter.should_receive(:say).with("Finished in 20 seconds")
+        reporter.should_receive(:say).with("10 tests, 0 failures", :green)
+        reporter.report_test_results
+      end
+    end
+  end
+end

--- a/spec/lib/reporters/retrieve_reporter_spec.rb
+++ b/spec/lib/reporters/retrieve_reporter_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+require 'metaforce/reporters/retrieve_reporter'
+
+describe Metaforce::Reporters::RetrieveReporter do
+  let(:results) { Hashie::Mash.new(success: true) }
+  let(:reporter) { described_class.new results }
+
+  describe '.report' do
+    it 'reports the problems' do
+      reporter.should_receive(:report_problems)
+      reporter.report
+    end
+  end
+end


### PR DESCRIPTION
Opening this up for review/discussion.

The goal is to provide a command line tool that makes it easy to deploy and retrieve code from Salesforce without using the Force.com IDE. The tool can watch a directory for changes and deploy whenever a file is saved, and also reports test results.

This implements the following tasks:

```
Tasks:
  metaforce deploy <path>               # Deploy <path> to the target organization.
  metaforce help [TASK]                 # Describe available tasks or one specific task
  metaforce retrieve <manifest> <path>  # Retrieve the components specified in <manifest> (package.xml) to <path>.
  metaforce watch <path>                # Deploy <path> to the target organization whenever files are changed.

```
