### PR TITLE
Update rubyzip version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in metaforce.gemspec
 gemspec

--- a/lib/metaforce/job.rb
+++ b/lib/metaforce/job.rb
@@ -1,4 +1,4 @@
-require 'zip/zip'
+require 'zip'
 require 'base64'
 
 module Metaforce

--- a/lib/metaforce/job/deploy.rb
+++ b/lib/metaforce/job/deploy.rb
@@ -75,7 +75,7 @@ module Metaforce
     def zip_file
       path = Dir.mktmpdir
       File.join(path, 'deploy.zip').tap do |path|
-        Zip::ZipFile.open(path, Zip::ZipFile::CREATE) do |zip|
+        Zip::File.open(path, Zip::File::CREATE) do |zip|
           Dir["#{@path}/**/**"].each do |file|
             zip.add(file.sub("#{File.dirname(@path)}/", ''), file)
           end

--- a/lib/metaforce/job/retrieve.rb
+++ b/lib/metaforce/job/retrieve.rb
@@ -74,7 +74,7 @@ module Metaforce
 
     # Internal: Unzips source to destination.
     def unzip(source, destination)
-      Zip::ZipFile.open(source) do |zip|
+      Zip::File.open(source) do |zip|
         zip.each do |f|
           path = File.join(destination, f.name)
           FileUtils.mkdir_p(File.dirname(path))

--- a/metaforce.gemspec
+++ b/metaforce.gemspec
@@ -22,7 +22,7 @@ EOL
   s.require_paths = ['lib']
 
   s.add_dependency 'savon', '~> 1.2.0'
-  s.add_dependency 'rubyzip', '~> 0.9.9'
+  s.add_dependency 'rubyzip', '~> 1.0'
   s.add_dependency 'activesupport'
   s.add_dependency 'hashie', '~> 1.2.0'
   s.add_dependency 'thor', '~> 0.16.0'


### PR DESCRIPTION
There is no reason not to upgrade and if you use a smaller version than 1.0. The requiring is different.

As I'm using another gem that uses rubyzip, the requiring gets really annoying.
