### PR TITLE
fixed missing highline gem dependency in metaforce.gemspec

### DIFF
--- a/metaforce.gemspec
+++ b/metaforce.gemspec
@@ -24,6 +24,7 @@ EOL
   s.add_dependency 'savon', '~> 1.2.0'
   s.add_dependency 'rubyzip', '~> 1.0'
   s.add_dependency 'activesupport'
+  s.add_dependency 'highline'
   s.add_dependency 'hashie', '~> 1.2.0'
   s.add_dependency 'thor', '~> 0.16.0'
   s.add_dependency 'listen', '~> 0.6.0'


### PR DESCRIPTION
This error was happening when I tried to run rake db:create

``` text
metadata_force_test 1.9.3 $ rake db:create
LoadError: cannot load such file -- highline
```

The gem **highline** is missing from the metaforce.gemspec and this commit fixes that issue. More info can be referenced here https://github.com/ejholmes/metaforce/issues/54.
