### PR TITLE
Lock rspec to version 2 & Update thor dependency

### DIFF
--- a/metaforce.gemspec
+++ b/metaforce.gemspec
@@ -25,12 +25,12 @@ EOL
   s.add_dependency 'rubyzip', '~> 1.0'
   s.add_dependency 'activesupport'
   s.add_dependency 'hashie', '~> 1.2.0'
-  s.add_dependency 'thor', '~> 0.16.0'
+  s.add_dependency 'thor', '~> 0.18.0'
   s.add_dependency 'listen', '~> 0.6.0'
   s.add_dependency 'rb-fsevent', '~> 0.9.1'
 
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'rspec', '2.14'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'savon_spec', '~> 1.3.0'
 end


### PR DESCRIPTION
Locks rspec to the latest version of version 2 to make sure tests pass (for ruby < 2.0).
Also updates thor dependency for use with current rails versions.

Addresses #49
