### PR TITLE
Require activesupport to prevent uninitialized constant ActiveSupport::Autoload error

### DIFF
--- a/lib/metaforce.rb
+++ b/lib/metaforce.rb
@@ -1,5 +1,6 @@
 require 'savon'
 require 'hashie'
+require 'active_support'
 require 'active_support/core_ext'
 
 require 'metaforce/version'


### PR DESCRIPTION
Currently when I try to load metaforce I get the following error (on ruby 2.5.1):

```ruby
Traceback (most recent call last):
	14: from metaforce.rb :1:in `<main>'
	13: from metaforce.rb :1:in `require'
	12: from /Users/josh/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/metaforce-1.1.0/lib/metaforce.rb:3:in `<top (required)>'
	11: from /Users/josh/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/metaforce-1.1.0/lib/metaforce.rb:3:in `require'
	10: from /Users/josh/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.0/lib/active_support/core_ext.rb:3:in `<top (required)>'
	 9: from /Users/josh/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.0/lib/active_support/core_ext.rb:3:in `each'
	 8: from /Users/josh/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.0/lib/active_support/core_ext.rb:4:in `block in <top (required)>'
	 7: from /Users/josh/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.0/lib/active_support/core_ext.rb:4:in `require'
	 6: from /Users/josh/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.0/lib/active_support/core_ext/numeric.rb:6:in `<top (required)>'
	 5: from /Users/josh/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.0/lib/active_support/core_ext/numeric.rb:6:in `require'
	 4: from /Users/josh/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.0/lib/active_support/core_ext/numeric/conversions.rb:4:in `<top (required)>'
	 3: from /Users/josh/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.0/lib/active_support/core_ext/numeric/conversions.rb:4:in `require'
	 2: from /Users/josh/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.0/lib/active_support/number_helper.rb:3:in `<top (required)>'
	 1: from /Users/josh/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.0/lib/active_support/number_helper.rb:4:in `<module:ActiveSupport>'
/Users/josh/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.0/lib/active_support/number_helper.rb:5:in `<module:NumberHelper>': uninitialized constant ActiveSupport::Autoload (NameError)
```

This is due to not including `require 'active_support'` being included before the `require 'active_support/core_ext' call as detailed in https://github.com/rails/rails/issues/14664 .